### PR TITLE
SQL Functions Auto-Exposed as GraphQL Fields

### DIFF
--- a/.spec/migrations/1695301364000_index_txs_by_timestamp/down.sql
+++ b/.spec/migrations/1695301364000_index_txs_by_timestamp/down.sql
@@ -1,0 +1,3 @@
+BEGIN;
+    DROP INDEX idx_allo_transaction_block_timestamp;
+COMMIT;

--- a/.spec/migrations/1695301364000_index_txs_by_timestamp/up.sql
+++ b/.spec/migrations/1695301364000_index_txs_by_timestamp/up.sql
@@ -1,0 +1,3 @@
+BEGIN;
+    CREATE INDEX idx_allo_transaction_block_timestamp ON public.allo_transaction(block_timestamp);
+COMMIT;

--- a/.spec/migrations/1695301493000_active_role_accounts_via_role/down.sql
+++ b/.spec/migrations/1695301493000_active_role_accounts_via_role/down.sql
@@ -1,0 +1,3 @@
+BEGIN;
+    DROP FUNCTION role_active_accounts(r role);
+COMMIT;

--- a/.spec/migrations/1695301493000_active_role_accounts_via_role/up.sql
+++ b/.spec/migrations/1695301493000_active_role_accounts_via_role/up.sql
@@ -1,0 +1,9 @@
+BEGIN;
+    CREATE FUNCTION role_active_accounts(r role) 
+    RETURNS setof role_account AS $$
+        SELECT ra.* FROM role_account ra 
+            WHERE ra.role_id = r.role_id 
+            AND ra.chain_id = r.chain_id 
+            AND is_active = true;
+    $$ LANGUAGE sql stable;
+COMMIT;

--- a/.spec/migrations/1695301779000_allo_transactions_from/down.sql
+++ b/.spec/migrations/1695301779000_allo_transactions_from/down.sql
@@ -1,0 +1,3 @@
+BEGIN;
+    DROP FUNCTION allo_transactions_from("chainId" varchar, "fromAddress" varchar);
+COMMIT;

--- a/.spec/migrations/1695301779000_allo_transactions_from/up.sql
+++ b/.spec/migrations/1695301779000_allo_transactions_from/up.sql
@@ -1,0 +1,9 @@
+BEGIN;
+    CREATE FUNCTION allo_transactions_from("chainId" varchar, "fromAddress" varchar) 
+    RETURNS setof allo_transaction AS $$
+        SELECT allo_transaction.* FROM allo_transaction 
+        WHERE chain_id = "chainId" 
+        AND from_address = "fromAddress";
+    $$ LANGUAGE sql STABLE;
+    COMMENT ON FUNCTION allo_transactions_from("chainId" varchar, "fromAddress" varchar) is E'@filterable\n@sortable';
+COMMIT;

--- a/.spec/migrations/1695301910000_allo_transactions_to/down.sql
+++ b/.spec/migrations/1695301910000_allo_transactions_to/down.sql
@@ -1,0 +1,3 @@
+BEGIN;
+    DROP FUNCTION allo_transactions_to("chainId" varchar, "toAddress" varchar);
+COMMIT;

--- a/.spec/migrations/1695301910000_allo_transactions_to/up.sql
+++ b/.spec/migrations/1695301910000_allo_transactions_to/up.sql
@@ -1,0 +1,9 @@
+BEGIN;
+    CREATE FUNCTION allo_transactions_to("chainId" varchar, "toAddress" varchar) 
+    RETURNS setof allo_transaction AS $$
+        SELECT allo_transaction.* FROM allo_transaction 
+        WHERE chain_id = "chainId" 
+        AND to_address = "toAddress";
+    $$ LANGUAGE sql STABLE;
+    COMMENT ON FUNCTION allo_transactions_to("chainId" varchar, "toAddress" varchar) is E'@filterable\n@sortable';
+COMMIT;

--- a/.spec/migrations/1695301962000_allo_transactions_involving/down.sql
+++ b/.spec/migrations/1695301962000_allo_transactions_involving/down.sql
@@ -1,0 +1,3 @@
+BEGIN;
+    DROP FUNCTION allo_transactions_involving("chainId" varchar, "address" varchar);
+COMMIT;

--- a/.spec/migrations/1695301962000_allo_transactions_involving/up.sql
+++ b/.spec/migrations/1695301962000_allo_transactions_involving/up.sql
@@ -1,0 +1,9 @@
+BEGIN;
+    CREATE FUNCTION allo_transactions_involving("chainId" varchar, "address" varchar) 
+    RETURNS setof allo_transaction AS $$
+        SELECT allo_transaction.* FROM allo_transaction 
+        WHERE chain_id = "chainId" 
+        AND (to_address = "address" OR from_address = "address");
+    $$ LANGUAGE sql STABLE;
+    COMMENT ON FUNCTION allo_transactions_involving("chainId" varchar, "address" varchar) is E'@filterable\n@sortable';
+COMMIT;


### PR DESCRIPTION
# Overview

This PR adds a handful of new SQL migrations, each unlocking specific functionality within the GraphQL schema.

### 1) index_txs_by_timestamp

Indexes `allo_transaction(block_timestamp)` which unlocks `order by block_timestamp` functionality when querying allo transactions from GraphQL.


### 2) active_role_accounts_via_role

Function that finds all active `role_account` records for a given `role`. 

#### GraphQL Usage:

```gql
{
  profiles {
    profileId
    anchor
    name
    chainId
    creator
    createdAt
    metadataPointer
    metadataProtocol
    nonce
    owner
    role {
      activeAccounts {
        accountId
      }
    }
  }
}
```

### 3) allo_transactions_from

Function that finds all Allo transactions sent _from_ a particular address (and chain id).

#### GraphQL Usage:

```gql
{
  alloTransactionsFrom(
    chainId: "5", 
    fromAddress: "0x4596039a69602b115752006ef8425f43d6e80a6f",
  ) {
    hash
    fromAddress
    toAddress
    functionName
    functionArgs
    blockHash
    blockNumber
    blockTimestamp
  }
}
```

### 4) allo_transactions_to

Function that finds all Allo transactions sent _to_ a particular address (and chain id).

#### GraphQL Usage:

```gql
{
  alloTransactionsTo(
    chainId: "5", 
    toAddress: "0x79536cc062ee8fafa7a19a5fa07783bd7f792206",
  ) {
    hash
    fromAddress
    toAddress
    functionName
    functionArgs
    blockHash
    blockNumber
    blockTimestamp
  }
}
```

### 5) allo_transactions_involving

Function that finds all Allo transactions sent _to or from_ a particular address (and chain id).

#### GraphQL Usage:

This example also shows how the results can be ordered by a particular column. The only requirement is that an index exists on that column, which is the reason for the `index_txs_by_timestamp` migration above.

```gql
{
  alloTransactionsInvolving(
    chainId: "5", 
    address: "0x79536cc062ee8fafa7a19a5fa07783bd7f792206",
    orderBy: [BLOCK_TIMESTAMP_DESC]
  ) {
    hash
    fromAddress
    toAddress
    functionName
    functionArgs
    blockHash
    blockNumber
    blockTimestamp
  }
}
```

# Running the migrations

Once this PR is merged, to sync these migrations to your local `alloscan` database:

#### 1) Make sure you're in the root of this repo locally, and you have the latest:

```bash
$ cd allo-scan && git pull
```

#### 2) Apply the new migrations to your database

```bash
$ spec migrate
```

#### 3) Start the GraphQL API and try out some of the new queries

```bash
$ spec run graphql
```
Open http://localhost:5555/graphiql